### PR TITLE
Added delays between register and data writes

### DIFF
--- a/OPL2.cpp
+++ b/OPL2.cpp
@@ -63,11 +63,13 @@ void OPL2::write(byte reg, byte data) {
 	SPI.transfer(reg);
 	digitalWrite(PIN_LATCH, LOW);
 	digitalWrite(PIN_LATCH, HIGH);
-
+	delayMicroseconds(4);
+	
 	digitalWrite(PIN_A0, HIGH);
 	SPI.transfer(data);
 	digitalWrite(PIN_LATCH, LOW);
 	digitalWrite(PIN_LATCH, HIGH);
+	delayMicroseconds(23);
 }
 
 


### PR DESCRIPTION
I have tried your library and I get somewhat inconsistent results. 

According to the Ad Lib Programming Guide after writing to the register port you must wait 3.3us before sending the data; after writing the data, 23us must elapse before any other YM3812 operation may be performed.

I have added those delays to OPL2.cpp and it seems to work consistently now.

Kind regards

Robert 