### PR TITLE
Fixed bug in calculating register offset

### DIFF
--- a/OPL2.cpp
+++ b/OPL2.cpp
@@ -64,7 +64,7 @@ void OPL2::write(byte reg, byte data) {
 	digitalWrite(PIN_LATCH, LOW);
 	digitalWrite(PIN_LATCH, HIGH);
 	delayMicroseconds(4);
-	
+
 	digitalWrite(PIN_A0, HIGH);
 	SPI.transfer(data);
 	digitalWrite(PIN_LATCH, LOW);
@@ -78,7 +78,7 @@ void OPL2::write(byte reg, byte data) {
  */
 byte OPL2::getRegisterOffset(byte ch, bool op2) {
 	ch = max(0, min(ch, 8));
-	return (6 * (ch / 3)) + (ch % 3) + (op2 ? 3 : 0);
+	return offset[op2][ch];
 }
 
 

--- a/OPL2.h
+++ b/OPL2.h
@@ -104,6 +104,10 @@ class OPL2 {
 			261.63, 293.66, 329.63, 349.23, 392.00, 440.00, 493.88, 523.26,
 			277.18, 311.13, 369.99, 415.30, 466.16
 		};
+		const byte offset[2][9] = {  
+			{0x00, 0x01, 0x02, 0x08, 0x09, 0x0A, 0x10, 0x11, 0x12} ,   /*  initializers for operator 0 */
+			{0x03, 0x04, 0x05, 0x0B, 0x0C, 0x0D, 0x13, 0x14, 0x15} ,   /*  initializers for operator 1 */
+		};
 		byte oplRegisters[256];
 		byte getRegisterOffset(byte, bool);
 };


### PR DESCRIPTION
Hi,

There seems to be a bug in the getRegisterOffset function as it was not returning the right values for anything above register 3. I have replaced it with a simple constant array which is not a particularly elegant solution, but is the way it was done in the official Ad Lib drivers.

Robert