### PR TITLE
Fix usage of play.py for Arduino

### DIFF
--- a/examples/SerialIface/play.py
+++ b/examples/SerialIface/play.py
@@ -28,7 +28,7 @@ Examples:
 
   %s COM4 k5t06.imf
   - Play k5t06.imf at the default frequency
-''' % ((sys.argv[0],) * 5)
+''' % ((sys.argv[0],) * 3)
   )
   sys.exit()
 


### PR DESCRIPTION
Otherwise, we get this error:

```
$ python3 play.py
Traceback (most recent call last):
  File "play.py", line 73, in <module>
    usage()
  File "play.py", line 31, in usage
    ''' % ((sys.argv[0],) * 5)
TypeError: not all arguments converted during string formatting
```