### PR TITLE
More VGM support for Arduino's play.py

### DIFF
--- a/examples/SerialIface/vgm.py
+++ b/examples/SerialIface/vgm.py
@@ -42,6 +42,11 @@ def play(opl, vgm_stream):
       delay_us = _samples_to_us(delay_samples)
     elif opcode == END_DATA:
       break
+    elif opcode >= 0x51 and opcode <= 0x5f:
+      # opcodes for writing to other YMF chips, skip
+      vgm_stream(2)
+    elif opcode == 0:
+      pass
     else:
       raise exc.InvalidFormatError('Unrecognized VGM opcode: 0x%02x' % opcode)
 


### PR DESCRIPTION
Some VGM (like zero_wing.vgz) contains a null opcode. We skip
it. opl2play.cpp seems to do the same thing. Some VGM also contain
commands for other chips. Skip those commands. Again, like
opl2play.cpp.

I still have many VGM not playing, but reading the spec, I see this is a quite complex format...