### PR TITLE
SerialIface.ino: ensure bufsize transmission is using only "\n"

### DIFF
--- a/examples/SerialIface/SerialIface.ino
+++ b/examples/SerialIface/SerialIface.ino
@@ -90,7 +90,8 @@ void waitForBufSizeCmd() {
     String cmd = Serial.readString();
     if (cmd.equals(BUF_SIZE_CMD)) {
       ready = true;
-      Serial.println(SERIAL_RX_BUFFER_SIZE);
+      Serial.print(SERIAL_RX_BUFFER_SIZE);
+      Serial.print("\n");
     }
   }
 }


### PR DESCRIPTION
Other commands are terminated by "\n", not "\r\n". The Python program
is unaffected by this as it handles both situation. However, other
programs may not and it seems better to make the protocol strict.