### PR TITLE
SerialIface.ino: add a variant protocol using less bytes

### DIFF
--- a/examples/SerialIface/SerialIface.ino
+++ b/examples/SerialIface/SerialIface.ino
@@ -55,7 +55,7 @@
 OPL2 opl2;
 
 // This function pointer will be set when in binary command mode.
-void (*processBinaryCmdFn)(void) = 0x0;
+void (*processCmdFn)(void) = &waitForBufSizeCmd;
 
 void setup() {
   opl2.init();
@@ -114,9 +114,9 @@ void waitForBufSizeCmd() {
     String cmd = Serial.readString();
     if (cmd.equals(BUF_SIZE_CMD) || cmd.equals(FAST_BUF_SIZE_CMD)) {
       if (cmd.equals(FAST_BUF_SIZE_CMD)) {
-        processBinaryCmdFn = &processFastBinaryCmds;
+        processCmdFn = &processFastBinaryCmds;
       } else {
-        processBinaryCmdFn = &processBinaryCmds;
+        processCmdFn = &processBinaryCmds;
       }
       Serial.print(SERIAL_RX_BUFFER_SIZE);
       Serial.print("\n");
@@ -125,10 +125,6 @@ void waitForBufSizeCmd() {
 }
 
 void loop() {
-  if (processBinaryCmdFn) {
-    processBinaryCmdFn();
-  } else {
-    waitForBufSizeCmd();
-  }
+  processCmdFn();
 }
 


### PR DESCRIPTION
Some games, like Another World, are sampling sounds with the OPL2. The
serial port becomes a bottleneck, whatever the buffer size
is. Therefore, the handshake is modified to let the user opt-in for
shorter binary commands (2 bytes) by using "B0F?" instead of "BUF?".

We use a different function to parse commands in fast mode to avoid
too many "if". I don't know if a simple CPU like the ATMega328P can do
effective branch prediction.

Note this PR also contains the commit for PR #19.