### PR TITLE
SerialIface.ino: display estimated delay while playing

### DIFF
--- a/examples/SerialIface/play.py
+++ b/examples/SerialIface/play.py
@@ -65,6 +65,8 @@ def handle_arguments():
         device = opl.ArduinoOpl(portname)
         player.play(device, f, **player_opts)
       except (KeyboardInterrupt, SystemExit):
+        pass
+      finally:
         device.close()
 
 


### PR DESCRIPTION
In play.py, we compare the current elapsed real time with the elapsed
play time to estimate a delay, display it and display the number of
underflows we get from it. Here is a notably difficult example:

 http://vgmrips.net/packs/pack/star-wars-x-wing-ibm-pc-at#02-opening-crawl

Despite a buffer of 1KiB, we still get many underflows, with delays up
to 1.5s.