### PR TITLE
SerialIface: reduce protocol to 2-byte commands

### DIFF
--- a/examples/SerialIface/opl.py
+++ b/examples/SerialIface/opl.py
@@ -1,4 +1,6 @@
 import struct
+import threading
+import time
 
 import serial
 
@@ -7,14 +9,14 @@ class ArduinoOpl:
   STARTUP_MSG = b'HLO!\n'
   READY_CMD = b'BUF?\n'
   ACK_RSP = b'k'
-  BINARY_CMD_SIZE = 5
+  BINARY_CMD_SIZE = 2
   RESET_CMD = b'\x00' * BINARY_CMD_SIZE
 
 
   def __init__(self, portname, baudrate=115200, debug=False):
     self.port = serial.Serial(portname, baudrate, timeout=None)
     self.ready = False
-    self.n_outstanding = 0
+    self.overdelay = 0
     self.debug = debug
 
     # Opening port resets Arduino. Wait for ready message.
@@ -24,10 +26,24 @@ class ArduinoOpl:
     self.port.write(self.READY_CMD)
     opl_rx_buf_bytes = int(self.port.readline())
     self._debug('Rx buffer size: %d bytes' % opl_rx_buf_bytes)
-    self.max_write_ahead = opl_rx_buf_bytes // self.BINARY_CMD_SIZE
+    self.buffer_size = opl_rx_buf_bytes // self.BINARY_CMD_SIZE
     self._status(self.READY_CMD)
 
+    self.sem = threading.Semaphore(self.buffer_size)
+    self.ack_thread = threading.Thread(target=self.ack)
+    self.ack_thread.daemon = True
+    self.ack_thread.start()
+
     self.ready = True
+
+  def ack(self):
+    while True:
+      rsp = self.port.read()
+      if rsp == '':
+        break
+      if rsp != self.ACK_RSP:
+        raise RuntimeError('Expected: %s, received: %s' % (rsp, self.ACK_RSP))
+      self.sem.release()
 
   def wait_for_rsp(self, rsp):
     self._debug('Awaiting: %s' % rsp)
@@ -42,29 +58,27 @@ class ArduinoOpl:
       raise RuntimeError('Expected: %s, received: %s' % (rsp, self.ACK_RSP))
     self.n_outstanding -= 1
 
-  def write_reg(self, addr, data, delay_us=0, predelay=False):
-    if self.n_outstanding >= self.max_write_ahead:
-      self.wait_for_ack()
-    self.write_reg_unbuffered(addr, data, delay_us, predelay)
+  def write_reg(self, addr, data, delay_us, predelay=False):
+    if predelay and delay_us > 0:
+      time.sleep(delay_us / 1000000.)
 
-  def write_reg_unbuffered(self, addr, data, delay_us, predelay):
-    delay_ms = delay_us // 1000
-    delay_remainder = delay_us % 1000
-    if predelay:
-      delay_ms = -delay_ms
-
-    cmd = struct.pack('!BBhB', addr, data, delay_ms, delay_remainder // 4)
-    self.n_outstanding += 1
+    cmd = struct.pack('!BB', addr, data)
+    if not self.sem.acquire(False):
+      self.overdelay += 1
+      self.sem.acquire()
     self.port.write(cmd)
     self._debug('Tx: %s' % ['%02x' % b for b in cmd])
-    if delay_us > 0:
-      self._debug('%8d.%03d milliseconds' % (delay_ms, delay_remainder))
+    if not predelay and delay_us > 0:
+      time.sleep(delay_us / 1000000.)
     self._status(cmd)
 
   def _status(self, last_tx):
     status = 'Initialized' if self.ready else 'Initializing'
     tx_txt = 'Tx: %s' % ' '.join('%02x' % b for b in last_tx)
-    status_str = "STATUS %-12s BUFFERED: %5d   %s" % (status, self.n_outstanding, tx_txt)
+    status_str = "STATUS %-12s BUFFER: %5d LATE: %3d   %s" % (status,
+                                                              self.buffer_size,
+                                                              self.overdelay,
+                                                              tx_txt)
     print("%s\r" % status_str.ljust(79), end='')
 
   def _debug(self, txt):
@@ -72,8 +86,9 @@ class ArduinoOpl:
       print(txt)
 
   def close(self):
-    while self.n_outstanding:
-      self.wait_for_ack()
+    for n in range(self.buffer_size):
+      self.sem.acquire()
     self.port.write(self.RESET_CMD)
     self._status(self.RESET_CMD)
     self.port.close()
+    print("")


### PR DESCRIPTION
Delay are computed on the client-side instead of the server-side. This
is less precise but this makes the protocol less chatty and able to
handle more complex tunes, like the opening of X-Wing. We use a
semaphore to represent the state of the buffer on the Arduino and a
separate thread handles acknowledgments.

I have not a good enough ear to know if there is a notable difference in the way tunes are rendered. I didn't find any tune not able to cope with a 256-byte buffer.

Related to #20 