### PR TITLE
OPL2Play DRO fix

### DIFF
--- a/examples_pi/opl2play/opl2play.cpp
+++ b/examples_pi/opl2play/opl2play.cpp
@@ -121,9 +121,9 @@ void playDroMusic(DRO dro) {
 		value        = fileData[offset ++];
 
 		if (registerCode == dro.codeShortDelay) {
-			delay(value);
+			delay(value + 1);
 		} else if (registerCode == dro.codeLongDelay) {
-			delay(value << 8);
+			delay((value + 1) << 8);
 		} else if (registerCode < 128) {
 			reg = dro.registerMap[registerCode];
 			opl2.write(reg, value);


### PR DESCRIPTION
This fixes a bug in OPL2Play where DRO file delays were 1ms too short,
causing some delays to be skipped completely and songs to be broken.

This fixes #40