### PR TITLE
Teensy midi fix

### DIFF
--- a/examples/Teensy/TeensyMidi/TeensyMidi.ino
+++ b/examples/Teensy/TeensyMidi/TeensyMidi.ino
@@ -126,6 +126,8 @@ void setOpl2ChannelVolume(byte opl2Channel, byte midiChannel) {
  * Handle a note on MIDI event to play a note.
  */
 void onNoteOn(byte channel, byte note, byte velocity) {
+	channel = channel % 16;
+
 	// Treat notes with a velocity of 0 as note off.
 	if (velocity == 0) {
 		onNoteOff(channel, note, velocity);


### PR DESCRIPTION
This fixes issues with the reuse of OPL2 channels in the TeensyMidi
sketch. Issues in the function to get a free OPL2 channel would return
the wrong channel causing clicks and pops. This fix eliminates this
issue mostly, though not fully as it also depends on the instrument
being used.

This fix is in reference to #44 