### PR TITLE
Instrument corrections

### DIFF
--- a/src/OPL2.h
+++ b/src/OPL2.h
@@ -176,7 +176,7 @@
 			const byte drumBits[5] = {
 				0x10, 0x08, 0x04, 0x02, 0x01
 			};
-			const byte instrumentBaseRegs[11] = {
+			const byte instrumentBaseRegs[6] = {
 				0x20, 0x40, 0x60, 0x80, 0xE0, 0xC0
 			};
 			byte oplRegisters[256];

--- a/src/instruments.h
+++ b/src/instruments.h
@@ -20,13 +20,13 @@
  *  4 - Channel c, operator 1, register 0x80
  *		Sustain(4) | Release(4)
  *
- *  5 - Channel c, register 0xC0
- *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
- *
- *  6 - Channel c, operator 1, register 0xE0
+ *  5 - Channel c, operator 1, register 0xE0
  *		Undefined(5) | Waveform(3)
  *
- *  7 - Channel c, operator 2, register 0x20 
+ *  6 - Channel c, register 0xC0
+ *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
+ *
+ *  7 - Channel c, operator 2, register 0x20
  *  8 - Channel c, operator 2, register 0x40
  *  9 - Channel c, operator 2, register 0x60
  * 10 - Channel c, operator 2, register 0x80

--- a/src/midi_drums.h
+++ b/src/midi_drums.h
@@ -21,13 +21,13 @@
  *  4 - Channel c, operator 1, register 0x80
  *		Sustain(4) | Release(4)
  *
- *  5 - Channel c, register 0xC0
- *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
- *
- *  6 - Channel c, operator 1, register 0xE0
+ *  5 - Channel c, operator 1, register 0xE0
  *		Undefined(5) | Waveform(3)
  *
- *  7 - Channel c, operator 2, register 0x20 
+ *  6 - Channel c, register 0xC0
+ *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
+ *
+ *  7 - Channel c, operator 2, register 0x20
  *  8 - Channel c, operator 2, register 0x40
  *  9 - Channel c, operator 2, register 0x60
  * 10 - Channel c, operator 2, register 0x80

--- a/src/midi_instruments.h
+++ b/src/midi_instruments.h
@@ -20,13 +20,13 @@
  *  4 - Channel c, operator 1, register 0x80
  *		Sustain(4) | Release(4)
  *
- *  5 - Channel c, register 0xC0
- *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
- *
- *  6 - Channel c, operator 1, register 0xE0
+ *  5 - Channel c, operator 1, register 0xE0
  *		Undefined(5) | Waveform(3)
  *
- *  7 - Channel c, operator 2, register 0x20 
+ *  6 - Channel c, register 0xC0
+ *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
+ *
+ *  7 - Channel c, operator 2, register 0x20
  *  8 - Channel c, operator 2, register 0x40
  *  9 - Channel c, operator 2, register 0x60
  * 10 - Channel c, operator 2, register 0x80

--- a/src/midi_instruments_win31.h
+++ b/src/midi_instruments_win31.h
@@ -20,13 +20,13 @@
  *  4 - Channel c, operator 1, register 0x80
  *		Sustain(4) | Release(4)
  *
- *  5 - Channel c, register 0xC0
- *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
- *
- *  6 - Channel c, operator 1, register 0xE0
+ *  5 - Channel c, operator 1, register 0xE0
  *		Undefined(5) | Waveform(3)
  *
- *  7 - Channel c, operator 2, register 0x20 
+ *  6 - Channel c, register 0xC0
+ *		Undefined(4) | Modulation feedback factor(3) | Synth type(1)
+ *
+ *  7 - Channel c, operator 2, register 0x20
  *  8 - Channel c, operator 2, register 0x40
  *  9 - Channel c, operator 2, register 0x60
  * 10 - Channel c, operator 2, register 0x80


### PR DESCRIPTION
This fixes an issue in comments of the instrument files. Regiseters 0x0E
and 0xC0 were swapped causing confusion. Also array size od
`instrumentBaseRegs` has been corrected.

This solves #48