### PR TITLE
ESP8266 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the OPL2 Audio Board library for Arduino, Teensy, Raspb
 * Emulation with DosBox; you can use the board to output MIDI music (Teensy++ 2.0 and later)
 * Use the board directly as a synthesizer by using the [OPL3BankEditor](https://github.com/Wohlstand/OPL3BankEditor) software by Wohlstand
 
-Current library version is 1.5.0
+Current library version is 1.5.1
 
 To obtain your own OPL2 Audio Board visit the [Tindie store](https://www.tindie.com/products/DhrBaksteen/opl2-audio-board/).
 

--- a/build
+++ b/build
@@ -18,8 +18,8 @@ echo "\033[1;36m   /    |    \\  |  / /_/ | |  ( /_/ )  |    |   ( /_/ ) __ \\| 
 echo "\033[1;34m   \\____|__  /____/\\____ | |__|\\___/   |______  /\\___(____  /__|  \\____ | "
 echo "\033[1;34m           \\/           \\/                    \\/          \\/           \\/ \033[0m"
 echo "Installation script for Raspberry Pi and compatibles"
-echo "Library version 1.5.0, 10th of November 2019"
-echo "Copyright (c) 2016-2019 Maarten Janssen, Cheerful"
+echo "Library version 1.5.1, 16th of Match 2020"
+echo "Copyright (c) 2016-2020 Maarten Janssen, Cheerful"
 echo ""
 
 MYDIR="${0%/*}"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino OPL2
-version=1.5.0
+version=1.5.1
 author=Maarten Janssen <maarten@cheerful.nl>
 maintainer=Maarten Janssen <maarten@cheerful.nl>
 sentence=Use this library to control the OPL2 Audio Board

--- a/src/OPL2.h
+++ b/src/OPL2.h
@@ -235,6 +235,16 @@
 				0x20, 0x40, 0x60, 0x80, 0xE0, 0xC0
 			};
 			byte oplRegisters[256];
+
+			const byte ZERO = 0;
+			const byte ONE = 1;
+			const byte CHANNEL_MAX = 8;
+			const byte OCTAVE_MAX = 7;
+			const byte NOTE_MAX = 11;
+			const short F_NUM_MIN = 0;
+			const short F_NUM_MAX = 1023;
+			const float VOLUME_MIN = 0.0;
+			const float VOLUME_MAX = 1.0;
 	};
 #endif
 


### PR DESCRIPTION
This change fixes issues with the library no longer compiling for
ESP8266 devices.

* Parameters to `min` and `max` function have been aligned to be of the
same type.