### PR TITLE
Drums Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the OPL2 Audio Board library for Arduino, Teensy, Raspb
 * Emulation with DosBox; you can use the board to output MIDI music (Teensy++ 2.0 and later)
 * Use the board directly as a synthesizer by using the [OPL3BankEditor](https://github.com/Wohlstand/OPL3BankEditor) software by Wohlstand
 
-Current library version is 1.5.2
+Current library version is 1.5.3
 
 To obtain your own OPL2 Audio Board visit the [Tindie store](https://www.tindie.com/products/DhrBaksteen/opl2-audio-board/).
 

--- a/build
+++ b/build
@@ -18,7 +18,7 @@ echo "\033[1;36m   /    |    \\  |  / /_/ | |  ( /_/ )  |    |   ( /_/ ) __ \\| 
 echo "\033[1;34m   \\____|__  /____/\\____ | |__|\\___/   |______  /\\___(____  /__|  \\____ | "
 echo "\033[1;34m           \\/           \\/                    \\/          \\/           \\/ \033[0m"
 echo "Installation script for Raspberry Pi and compatibles"
-echo "Library version 1.5.2, 10th of April 2020"
+echo "Library version 1.5.3, 10th of April 2020"
 echo "Copyright (c) 2016-2020 Maarten Janssen, Cheerful"
 echo ""
 

--- a/examples/PianoBoard/PianoBoard.ino
+++ b/examples/PianoBoard/PianoBoard.ino
@@ -1,5 +1,6 @@
 /**
- * This is a simple demo sketch for the OPL2 library. It makes use of the Piano Board and assumes then you also have the
+ * This is a simple demo sketch for the OPL2 library. It makes use of the Cheerful Electronic Piano Board
+ * (https://www.tindie.com/products/cheerful/arduino-piano-board-2/) and assumes then you also have the
  * ArduinoPianoBoard library installed (see https://github.com/DhrBaksteen/ArduinoPianoBoard).
  *
  * This sketch makes a simple piano out of the OPL2 Board and the Piano Board. Use the piano keys to play a tune. User

--- a/examples/PianoBoardDrummer/PianoBoardDrummer.ino
+++ b/examples/PianoBoardDrummer/PianoBoardDrummer.ino
@@ -1,0 +1,68 @@
+/**
+ * This is a simple demo sketch for the OPL2 library. It makes use of the Cheerful Electronic Piano Board
+ * (https://www.tindie.com/products/cheerful/arduino-piano-board-2/) and assumes then you also have the
+ * ArduinoPianoBoard library installed (see https://github.com/DhrBaksteen/ArduinoPianoBoard).
+ *
+ * This sketch makes a drum machine out of the Piano Board. The first 5 white keys are used to play various drum sounds.
+ * 
+ * OPL2 Board is connected as follows:
+ *   Pin  8 - Reset
+ *   Pin  9 - A0
+ *   Pin 10 - Latch
+ *   Pin 11 - Data
+ *   Pin 13 - Shift
+ * 
+ * Piano Board is connected as follows:
+ *   Pin 7  - /SS
+ *   Pin 12 - MISO
+ *   Pin 13 - SCK
+ * 
+ * Code by Maarten Janssen (maarten@cheerful.nl) 2020-04-11
+ * Most recent version of the library can be found at my GitHub: https://github.com/DhrBaksteen/ArduinoOPL2
+ */
+
+#include <SPI.h>
+#include <OPL2.h>
+#include <PianoKeys.h>
+#include <instruments.h>
+
+#define NO_DRUM 255
+
+OPL2 opl2;
+PianoKeys piano(7);
+
+
+byte drums[8] = {DRUM_BASS, NO_DRUM, DRUM_SNARE, NO_DRUM, DRUM_TOM, DRUM_HI_HAT, NO_DRUM, DRUM_CYMBAL};
+
+
+void setup() {
+	opl2.init();
+
+	// Load drum instruments and set percusive mode.
+	Instrument bass = opl2.loadInstrument(INSTRUMENT_BDRUM1);
+	Instrument snare = opl2.loadInstrument(INSTRUMENT_RKSNARE1);
+	Instrument tom = opl2.loadInstrument(INSTRUMENT_TOM2);
+	Instrument cymbal = opl2.loadInstrument(INSTRUMENT_CYMBAL1);
+	Instrument hihat = opl2.loadInstrument(INSTRUMENT_HIHAT2);
+
+	opl2.setPercussion(true);
+	opl2.setDrumInstrument(bass);
+	opl2.setDrumInstrument(snare);
+	opl2.setDrumInstrument(tom);
+	opl2.setDrumInstrument(cymbal);
+	opl2.setDrumInstrument(hihat);
+}
+
+
+void loop() {
+	piano.updateKeys();
+
+	// Handle keys that are being pressed.
+	for (int i = KEY_C; i <= KEY_G; i ++) {
+		if (piano.wasKeyPressed(i) && drums[i] != NO_DRUM) {
+			opl2.playDrum(drums[i], 4, NOTE_C);
+		}
+	}
+
+	delay(20);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino OPL2
-version=1.5.2
+version=1.5.3
 author=Maarten Janssen <maarten@cheerful.nl>
 maintainer=Maarten Janssen <maarten@cheerful.nl>
 sentence=Use this library to control the OPL2 Audio Board

--- a/src/OPL2.h
+++ b/src/OPL2.h
@@ -51,11 +51,18 @@
 	#define ADDITIVE_SYNTH  true
 
 	// Drum sounds.
-	#define DRUM_BASS   0x10
-	#define DRUM_SNARE  0x08
-	#define DRUM_TOM    0x04
-	#define DRUM_CYMBAL 0x02
-	#define DRUM_HI_HAT 0x01
+	#define DRUM_BASS   0
+	#define DRUM_SNARE  1
+	#define DRUM_TOM    2
+	#define DRUM_CYMBAL 3
+	#define DRUM_HI_HAT 4
+
+	// Drum sound bit masks.
+	#define DRUM_BITS_BASS   0x10
+	#define DRUM_BITS_SNARE  0x08
+	#define DRUM_BITS_TOM    0x04
+	#define DRUM_BITS_CYMBAL 0x02
+	#define DRUM_BITS_HI_HAT 0x01
 
 	// Note to frequency mapping.
 	#define NOTE_C   0
@@ -195,6 +202,7 @@
 			byte setDeepTremolo(bool enable);
 			byte setDeepVibrato(bool enable);
 			byte setPercussion(bool enable);
+			byte setDrums(byte drums);
 			byte setDrums(bool bass, bool snare, bool tom, bool cymbal, bool hihat);
 			byte setWaveForm(byte channel, byte operatorNum, byte waveForm);
 
@@ -229,7 +237,7 @@
 				6, 7, 8, 8, 7
 			};
 			const byte drumBits[5] = {
-				0x10, 0x08, 0x04, 0x02, 0x01
+				DRUM_BITS_BASS, DRUM_BITS_SNARE, DRUM_BITS_TOM, DRUM_BITS_CYMBAL, DRUM_BITS_HI_HAT
 			};
 			const byte instrumentBaseRegs[6] = {
 				0x20, 0x40, 0x60, 0x80, 0xE0, 0xC0
@@ -241,6 +249,7 @@
 			const byte CHANNEL_MAX = 8;
 			const byte OCTAVE_MAX = 7;
 			const byte NOTE_MAX = 11;
+			const byte DRUM_SOUND_MAX = 5;
 			const short F_NUM_MIN = 0;
 			const short F_NUM_MAX = 1023;
 			const float VOLUME_MIN = 0.0;


### PR DESCRIPTION
This update makes a few changes to how drums are handled in percusive
mode and adds a new example that makes use of the Piano Board.

* New definitions for the drum sounds. Old definition is renamed to
  DRUM_BITS.
* Added a variant on the setDrums function that allows you to update the
  bits of the drum register using a byte value.
* Added the playDrums function that allows playing a single drum
  instrument at a particular frequency.
* Added the PianoBoardDrummer example that turns the Cheerful Electronic
  Piano Board into a drum machine.