### PR TITLE
Adapt v1.4.6/examples/SerialIface/opl.py to SerialPassthrough

### DIFF
--- a/examples/SerialPassthrough/exc.py
+++ b/examples/SerialPassthrough/exc.py
@@ -1,0 +1,5 @@
+class InvalidFormatError(Exception):
+  pass
+
+class InvalidDeviceError(Exception):
+  pass

--- a/examples/SerialPassthrough/imf.py
+++ b/examples/SerialPassthrough/imf.py
@@ -1,0 +1,42 @@
+import collections
+import struct
+
+IMF_FREQUENCIES = collections.defaultdict(lambda: 560)
+IMF_FREQUENCIES.update({
+    'duke': 280,
+    'wolf': 700,
+    'wlf': 700
+})
+
+
+def parse_args(file_extension, args):
+  frequency_hz = IMF_FREQUENCIES['default']
+  if not args:
+    frequency_hz = IMF_FREQUENCIES[file_extension]
+  else:
+    try:
+      frequency_hz = int(args[0])
+    except ValueError:
+      frequency_hz = IMF_FREQUENCIES[args[0].lower()]
+  return {'frequency_hz': frequency_hz}
+
+
+def play(opl, imf_stream, **kwargs):
+  song_length, = struct.unpack('H', imf_stream.read(2))
+
+  if song_length == 0:
+    imf_type = 0
+    imf_stream.read(2)
+  else:
+    imf_type = 1
+
+  i = 0
+  while imf_type == 0 or imf_type == 1 and i < song_length:
+    cmd = imf_stream.read(4)
+    if len(cmd) < 4:
+      break
+
+    addr, data, delay_cycles = struct.unpack_from('BBH', cmd)
+    delay_us = 1000000 * delay_cycles // kwargs['frequency_hz']
+    opl.write_reg(addr, data, delay_us)
+    i += 4

--- a/examples/SerialPassthrough/opl.py
+++ b/examples/SerialPassthrough/opl.py
@@ -1,0 +1,45 @@
+import struct
+
+import serial
+
+from time import sleep
+
+class ArduinoOpl:
+
+  def __init__(self, portname, baudrate=115200, debug=False):
+    self.port = serial.Serial(portname, baudrate, timeout=None)
+    self.debug = debug
+    self.status = 'Initializing'
+    self.reset()
+    self.status = 'Initialized'
+
+  def write_reg(self, addr, data, delay_us=0, predelay=False):
+    delay_ms = delay_us // 1000
+    delay_remainder = delay_us % 1000
+    cmd = struct.pack('>BB', addr, data)
+    if predelay and delay_ms > 0:
+        sleep(delay_us / 1000000.0)
+    self.port.write(cmd)
+    self._status(cmd)
+    self._debug('Tx: %s' % ['%02x' % b for b in cmd])
+    if (not predelay) and delay_ms > 0:
+      sleep(delay_us / 1000000.0)
+
+  def _status(self, last_tx):
+    tx_txt = 'Tx: %s' % ' '.join('%02x' % b for b in last_tx)
+    status_str = "STATUS %-12s    %s" % (self.status, tx_txt)
+    print("%s\r" % status_str.ljust(79), end='')
+
+  def _debug(self, txt):
+    if self.debug:
+      print(txt)
+
+  def reset(self):
+      for reg in range(0, 256):
+          self.write_reg(reg, 0x00)
+
+  def close(self):
+    self.status = 'Closing'
+    self.reset()
+    self.port.close()
+    print("")

--- a/examples/SerialPassthrough/play.py
+++ b/examples/SerialPassthrough/play.py
@@ -1,0 +1,78 @@
+# Interpret and stream a music file via the serial interface of the Arduino OPL shield.
+
+import sys
+
+import exc
+import opl
+import imf
+import vgm
+import vgz
+
+
+def usage():
+  print(
+      '''Arduino OPL2 streaming player
+
+Usage:
+   %s <serial_port> [<input_file> [<player_specific_options>]]
+
+   - serial_port: the name of the Arduino USB serial port
+   - input_file: the path to a supported input file
+   - player_specific_options:
+     - IMF: [<frequency_hz>]
+       - frequency_hz: one of 'wolf', 'duke', or an integer value (Hz)
+
+Examples:
+
+  %s COM4
+  - Connect to and initialize the Arduino board on COM4
+
+  %s COM4 k5t06.imf
+  - Play k5t06.imf at the default frequency
+''' % ((sys.argv[0],) * 3)
+  )
+  sys.exit()
+
+
+PLAYERS = {
+    'imf': imf,
+    'wlf': imf,
+    'vgm': vgm,
+    'vgz': vgz
+}
+
+def handle_arguments():
+  portname = sys.argv[1]
+  if len(sys.argv) > 2:
+    filename = sys.argv[2]
+    extension = filename.split('.')[-1].lower()
+
+    try:
+      player = PLAYERS[extension]
+    except KeyError:
+      print('Unrecognized file extension: %s' % extension)
+      sys.exit(-1)
+
+    with open(filename, 'rb') as f:
+      try:
+        player_opts = player.parse_args(extension, sys.argv[3:])
+      except AttributeError:
+        player_opts = {}
+      try:
+        print('Play "%s" on %s' % (filename, portname))
+        if player_opts:
+          print('Options: %s' % player_opts)
+        print('(Ctrl-C to stop)')
+        device = opl.ArduinoOpl(portname)
+        player.play(device, f, **player_opts)
+      except (KeyboardInterrupt, SystemExit):
+        device.close()
+      except exc.InvalidDeviceError as e:
+        device.close()
+        print(e)
+
+
+if __name__ == '__main__':
+  if len(sys.argv) <= 1:
+    usage()
+  handle_arguments()

--- a/examples/SerialPassthrough/vgm.py
+++ b/examples/SerialPassthrough/vgm.py
@@ -1,0 +1,77 @@
+import struct
+
+import exc
+
+SAMPLE_RATE = 44100
+YM3812 = 0x5a
+DELAY_N = 0x61
+DELAY_735 = 0x62
+DELAY_882 = 0x63
+DELAY_N1 = 0x70
+END_DATA = 0x66
+
+YM_CHIP_1 = 0x50 # 1st YM chip commands
+YM_CHIP_2 = 0xa0 # 2nd YM chip commands
+
+
+def _samples_to_us(n):
+  return 1000000 * n // SAMPLE_RATE
+
+def play(opl, vgm_stream):
+  data_offset = parse_header(vgm_stream)
+  vgm_stream.seek(data_offset)
+
+  delay_us = 0
+
+  cmd = None
+  while True:
+    cmd = vgm_stream.read(1)
+    if len(cmd) < 1:
+      break
+    opcode = cmd[0]
+
+    if YM3812 == opcode:
+      addr, data = struct.unpack_from('BB', vgm_stream.read(2))
+      opl.write_reg(addr, data, delay_us, True)
+      delay_us = 0
+    elif DELAY_N == opcode:
+      delay_samples, = struct.unpack_from('H', vgm_stream.read(2))
+      delay_us += _samples_to_us(delay_samples)
+    elif DELAY_735 == opcode:
+      delay_us += _samples_to_us(735)
+    elif DELAY_882 == opcode:
+      delay_us += _samples_to_us(882)
+    elif DELAY_N1 == opcode & 0xf0:
+      delay_samples = 1 + int(opcode & 0xf)
+      delay_us += _samples_to_us(delay_samples)
+    elif opcode == END_DATA:
+      break
+    elif (opcode & 0xf0) in (YM_CHIP_1, YM_CHIP_2):
+      vgm_stream.read(2 if (opcode & 0x0f) else 1)
+    else:
+      raise exc.InvalidFormatError('Unrecognized VGM opcode: 0x%02x' % opcode)
+
+
+def parse_header(vgm_stream):
+  ident = vgm_stream.read(4)
+
+  if ident != b'Vgm ':
+    raise exc.InvalidFormatError('vgm')
+
+  vgm_stream.seek(8)
+  version, = struct.unpack('<I', vgm_stream.read(4))
+  ver_major = (version >> 8) & 0xff
+  ver_minor = version & 0xff
+
+  data_offset = 0x40
+  if ver_major >= 0x1 and ver_minor >= 0x50:
+    vgm_stream.seek(0x34)
+    data_offset, = struct.unpack('<I', vgm_stream.read(4))
+    vgm_stream.seek(0x50)
+    ym3812_clock, = struct.unpack('<I', vgm_stream.read(4))
+    if not ym3812_clock:
+      raise exc.InvalidDeviceError(
+        'No YM3812 clock specified. VGM data for another chip.'
+      )
+
+  return 0x100 + data_offset

--- a/examples/SerialPassthrough/vgz.py
+++ b/examples/SerialPassthrough/vgz.py
@@ -1,0 +1,7 @@
+import gzip
+
+import vgm
+
+def play(opl, vgz_stream):
+  gzf = gzip.GzipFile(fileobj=vgz_stream, mode='rb')
+  vgm.play(opl, gzf)


### PR DESCRIPTION
* Hard reset the OPL2 on __init__ and close
* Implement delays (sloppily) in opl.py

Thanks to @vincentbernat for pointing out play.py on
https://vincent.bernat.ch/en/blog/2018-opl2-audio-board !

Enjoy https://vgmrips.net/packs/chip/ym3812 out of the box