### PR TITLE
OPL3Duo SerialPassthrough

### DIFF
--- a/examples/OPL2AudioBoard/Teensy/TeensyMidi/TeensyMidi.ino
+++ b/examples/OPL2AudioBoard/Teensy/TeensyMidi/TeensyMidi.ino
@@ -141,11 +141,11 @@ void onNoteOn(byte midiChannel, byte note, byte velocity) {
 		return;
 	}
 
-		// Register channel mapping.
-		byte opl2Channel = getFreeChannel(midiChannel);
-		opl2ChannelMap[opl2Channel].midiChannel  = midiChannel;
-		opl2ChannelMap[opl2Channel].midiNote     = note;
-		opl2ChannelMap[opl2Channel].noteVelocity = log(min((float)velocity, 127.0)) / log(127.0);
+	// Register channel mapping.
+	byte opl2Channel = getFreeChannel(midiChannel);
+	opl2ChannelMap[opl2Channel].midiChannel  = midiChannel;
+	opl2ChannelMap[opl2Channel].midiNote     = note;
+	opl2ChannelMap[opl2Channel].noteVelocity = log(min((float)velocity, 127.0)) / log(127.0);
 
 	// For notes on drum channel the note determines the instrument to load.
 	if (midiChannel == MIDI_DRUM_CHANNEL && note >= DRUM_NOTE_BASE && note < DRUM_NOTE_BASE + NUM_MIDI_DRUMS) {
@@ -153,19 +153,19 @@ void onNoteOn(byte midiChannel, byte note, byte velocity) {
 		midiChannelMap[MIDI_DRUM_CHANNEL].instrument = opl2.loadInstrument(instrumentDataPtr);
 	}
 
-		// Calculate octave and note number.
-		byte opl2Octave = 4;
-		byte opl2Note = NOTE_C;
-		if (midiChannel != MIDI_DRUM_CHANNEL) {
-			note = max(24, min(note, 119));
-			opl2Octave = 1 + (note - 24) / 12;
-			opl2Note   = note % 12;
-		}
-
-		// Set instrument registers and play note.
-		opl2.setInstrument(opl2Channel, midiChannelMap[midiChannel].instrument, opl2ChannelMap[opl2Channel].noteVelocity);
-		opl2.playNote(opl2Channel, opl2Octave, opl2Note);
+	// Calculate octave and note number.
+	byte opl2Octave = 4;
+	byte opl2Note = NOTE_C;
+	if (midiChannel != MIDI_DRUM_CHANNEL) {
+		note = max(24, min(note, 119));
+		opl2Octave = 1 + (note - 24) / 12;
+		opl2Note   = note % 12;
 	}
+
+	// Set instrument registers and play note.
+	opl2.setInstrument(opl2Channel, midiChannelMap[midiChannel].instrument, opl2ChannelMap[opl2Channel].noteVelocity);
+	opl2.playNote(opl2Channel, opl2Octave, opl2Note);
+}
 
 
 /**

--- a/examples/OPL3Duo/SerialPassthrough/SerialPassthrough.ino
+++ b/examples/OPL3Duo/SerialPassthrough/SerialPassthrough.ino
@@ -1,0 +1,38 @@
+/**
+ * This demonstration sketch for the OPL3 Duo shows how you can use an Arduino to receive serial data to control the
+ * OPL3 Duo board. The 'protocol' implemented in this sketch is very simple. It expects 3 bytes [BANK, REGISTER, DATA]
+ * for every register write to one of the chips.
+ *
+ * The BANK is defined as follows:
+ *    bits 7 .. 2 - Unused
+ *    bit  1      - Chip 0 or 1
+ *    bit  0      - Bank 0 or 1
+ * The REGISTER sets the register of the selected chip and bank to write to.
+ * The DATA defines the data to write to the selected register.
+ *
+ * You can change and improve the serial transfer to suit your application.
+ *
+ * Code by Maarten Janssen, 2020-11-07
+ * WWW.CHEERFUL.NL
+ * Most recent version of the library can be found at my GitHub: https://github.com/DhrBaksteen/ArduinoOPL2
+ */
+
+#include <SPI.h>
+#include <OPL3Duo.h>
+
+OPL3Duo opl3Duo;
+
+void setup() {
+	Serial.begin(115200);
+	opl3Duo.begin();
+}
+
+void loop() {
+	while (Serial.available() > 2) {
+		byte bank = Serial.read() & 0x03;
+		byte reg = Serial.read();
+		byte val = Serial.read();
+
+		opl3Duo.write(bank, reg, val);
+	}
+}

--- a/examples_pi/frequency_sweep/sweep.cpp
+++ b/examples_pi/frequency_sweep/sweep.cpp
@@ -15,6 +15,7 @@
 
 
 #include <OPL2.h>
+#include <math.h>
 #include <wiringPi.h>
 
 
@@ -25,21 +26,19 @@ int main(int argc, char **argv) {
 
 	// Setup channel 0 carrier.
 	opl2.setMaintainSustain(0, CARRIER, true);
-	opl2.setMultiplier(0, CARRIER, 0x04);
+	opl2.setMultiplier(0, CARRIER, 0x01);
 	opl2.setAttack    (0, CARRIER, 0x0A);
 	opl2.setSustain   (0, CARRIER, 0x04);
+	opl2.setVolume    (0, CARRIER, 0x00);
 
 	// Start tone.
+	float t = 0.0;
 	opl2.setKeyOn(0, true);
 	while (true) {
-		for (int f = 250; f < 750; f += 10) {
-			opl2.setFrequency(0, f);
-			delay(10);
-		}
+		float freq = sin(t) * 250 + 500;
+		opl2.setFrequency(0, freq);
 
-		for (int f = 750; f > 250; f -= 10) {
-			opl2.setFrequency(0, f);
-			delay(10);
-		}
+		t += .01;
+		delay(10);
 	}
 }

--- a/examples_pi/simpletone/simpletone.cpp
+++ b/examples_pi/simpletone/simpletone.cpp
@@ -34,10 +34,11 @@ int main(int argc, char **argv) {
 		opl2.setDecay     (i, CARRIER, 0x04);
 		opl2.setSustain   (i, CARRIER, 0x0F);
 		opl2.setRelease   (i, CARRIER, 0x0F);
+		opl2.setVolume    (i, CARRIER, 0x00);
 	}
 
 	// Play notes on alternating channels.
-	for (byte i = 0; i < 13; i ++) {
+	for (byte i = 0; i < 24; i ++) {
 		byte octave = 3 + (i / 12);
 		byte note = i % 12;
 		opl2.playNote(i % 3, octave, note);


### PR DESCRIPTION
* This adds an example for serial data transfer to the OPL3 Duo board
* Align two examples for the Raspberry Pi with their Arduino equivalents
* Cleanup of TeensyMidi code for OPL2 Audio Board