### PR TITLE
Fix OPL3 Duo pin definitions for Arduino

### DIFF
--- a/src/OPL3.h
+++ b/src/OPL3.h
@@ -13,7 +13,12 @@
 	#define SYNTH_MODE_AM_AM 3
 
 	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
-		#define PIN_BANK 7
+		#undef PIN_ADDR					// Undefine A0 and /IC pins from OPL2 and redefine for OPL3 Duo.
+		#undef PIN_RESET
+
+		#define PIN_BANK  7
+		#define PIN_ADDR  8
+		#define PIN_RESET 9
 	#else
 		#define PIN_BANK 5				// GPIO header pin 18
 	#endif


### PR DESCRIPTION
This fixes #68 that caused the OPL3 Duo to only produce clicking noises due to the pint for A0 and /IC being swapped. They were not redefined in #66 