### PR TITLE
Handle stopNote correctly in MidiSynth example

### DIFF
--- a/examples/OPL2AudioBoard/MidiSynth/MidiSynth.ino
+++ b/examples/OPL2AudioBoard/MidiSynth/MidiSynth.ino
@@ -176,7 +176,7 @@ void stopNote() {
 	for (byte i = 0; i < NUM_OPL2_CHANNELS; i ++) {
 		if (oplNotes[i] == note) {
 			oplNotes[i] = NO_NOTE;
-			opl2.setKeyOn(1, false);
+			opl2.setKeyOn(i, false);
 		}
 	}
 }


### PR DESCRIPTION
I'm still waiting on a connector cable to arrive, so I haven't tested this, but I think this is meant to be `i` not `1`.
Wanted to send this before I forget -- I'm happy to test it out in a day or two. 