### PR TITLE
Update mask used in setWaveForm / getWaveForm to preserve 3rd bit for opl3

### DIFF
--- a/src/OPL2.cpp
+++ b/src/OPL2.cpp
@@ -607,7 +607,7 @@ void OPL2::setDrumInstrument(Instrument instrument, float volume) {
 				((instrument.operators[op].sustain & 0x0F) << 4) +
 				(instrument.operators[op].release & 0x0F));
 			setOperatorRegister(0xE0, channel, op,
-				(instrument.operators[op].waveForm & 0x03));
+				(instrument.operators[op].waveForm & 0x07));
 		}
 	}
 
@@ -1108,7 +1108,7 @@ void OPL2::setDrums(bool bass, bool snare, bool tom, bool cymbal, bool hihat) {
  * Get the wave form currently set for the given channel.
  */
 byte OPL2::getWaveForm(byte channel, byte operatorNum) {
-	return getOperatorRegister(0xE0, channel, operatorNum) & 0x03;
+	return getOperatorRegister(0xE0, channel, operatorNum) & 0x07;
 }
 
 
@@ -1116,6 +1116,6 @@ byte OPL2::getWaveForm(byte channel, byte operatorNum) {
  * Select the wave form to use.
  */
 void OPL2::setWaveForm(byte channel, byte operatorNum, byte waveForm) {
-	byte value = getOperatorRegister(0xE0, channel, operatorNum) & 0xFC;
-	setOperatorRegister(0xE0, channel, operatorNum, value + (waveForm & 0x03));
+	byte value = getOperatorRegister(0xE0, channel, operatorNum) & 0xF8;
+	setOperatorRegister(0xE0, channel, operatorNum, value + (waveForm & 0x07));
 }


### PR DESCRIPTION
Was trying to figure out why my waveforms didn't sound right, then found this.
Note that setInstrumet uses the right mask, which is why loading presets / whole instruments works fine.

Far as I can tell it's fine to have this extra 3rd bit around even on an opl2 (though it won't be respected) -- since setInstrument does that already.

I updated setDrumInstrument as well, but I've not read up on the details for drums yet so let me know if I should remove that one.