### PR TITLE
Clamping function

### DIFF
--- a/examples/OPL2AudioBoard/MidiSynth/MidiSynth.ino
+++ b/examples/OPL2AudioBoard/MidiSynth/MidiSynth.ino
@@ -31,6 +31,9 @@
 #define NUM_OPL2_CHANNELS 9
 #define NO_NOTE 255
 
+const byte MIN_NOTE = 24;
+const byte MAX_NOTE = 119;
+
 byte midiCommand = 0x00;
 byte midiChannel = 0;
 byte midiData[2] = { 0x00, 0x00 };
@@ -156,7 +159,7 @@ void playNote() {
 	oplNotes[oplChannel] = note;
 
 	// Adjust note to valid range and extract octave.
-	note = max(24, min(note, 119));
+	note = max(MIN_NOTE, min(note, MAX_NOTE));
 	byte octave = 1 + (note - 24) / 12;
 	note = note % 12;
 	opl2.playNote(oplChannel, octave, note);

--- a/examples_pi/OPL3Duo/DemoTune/TuneParser.cpp
+++ b/examples_pi/OPL3Duo/DemoTune/TuneParser.cpp
@@ -1,5 +1,6 @@
 #include "TuneParser.h"
 #include <wiringPi.h>
+#include <algorithm>
 
 
 /**
@@ -206,7 +207,7 @@ Tune TuneParser::playBackground(const char* voice0, const char* voice1, const ch
 Tune TuneParser::createTune(const char* voices[6], int numVoices) {
 	Tune tune;
 
-	tune.numVoices = min(numVoices, 6);
+	tune.numVoices = std::min(numVoices, 6);
 	for (byte i = 0; i < tune.numVoices; i ++) {
 		tune.voice[i].pattern = voices[i];
 	}
@@ -440,13 +441,13 @@ void TuneParser::parseNote(Voice& voice) {
 		voice.position ++;
 		note = notes[1][noteIndex];
 		if (note == NOTE_B) {
-			octave = max(octave - 1, 0);
+			octave = std::max(octave - 1, 0);
 		}
 	} else if (sharpFlat == TUNE_CMD_NOTE_SHARP || sharpFlat == TUNE_CMD_NOTE_SHARP2) {
 		voice.position ++;
 		note = notes[2][noteIndex];
 		if (note == NOTE_C) {
-			octave = min(octave + 1, 7);
+			octave = std::min(octave + 1, 7);
 		}
 	}
 
@@ -531,7 +532,7 @@ byte TuneParser::parseNoteLength(Voice voice) {
  * @param nMax - Maximum value of the number.
  * @return The number at the current command position in the voice or TP_NAN.
  */
-byte TuneParser::parseNumber(Voice voice, byte nMin, byte nMax) {
+byte TuneParser::parseNumber(Voice voice, int nMin, int nMax) {
 	char nextDigit = voice.pattern[voice.position + 1];
 	if (nextDigit < '0' || nextDigit > '9') {
 		return TP_NAN;
@@ -545,5 +546,5 @@ byte TuneParser::parseNumber(Voice voice, byte nMin, byte nMax) {
 		nextDigit = voice.pattern[voice.position + 1];
 	}
 
-	return (byte)max(nMin, min(number, nMax));
+	return (byte)std::max(nMin, std::min(number, nMax));
 }

--- a/examples_pi/OPL3Duo/DemoTune/TuneParser.h
+++ b/examples_pi/OPL3Duo/DemoTune/TuneParser.h
@@ -76,7 +76,7 @@ class TuneParser {
 		void parseNote(Voice& voice);
 		void parseRest(Voice& voice);
 		byte parseNoteLength(Voice voice);
-		byte parseNumber(Voice voice, byte nMin, byte nMax);
+		byte parseNumber(Voice voice, int nMin, int nMax);
 
 	private:
 		OPL3Duo* opl3 = NULL;

--- a/src/OPL2.cpp
+++ b/src/OPL2.cpp
@@ -365,7 +365,7 @@ byte OPL2::getNumChannels() {
  */
 short OPL2::getFrequencyFNumber(byte channel, float frequency) {
 	float fInterval = getFrequencyStep(channel);
-	return max((short)0, min((short)(frequency / fInterval), (short)1023));
+	return clampValue((short)(frequency / fInterval), (short)0, (short)1023);
 }
 
 
@@ -543,7 +543,7 @@ Instrument OPL2::getDrumInstrument(byte drumType) {
  * operators.
  */
 void OPL2::setInstrument(byte channel, Instrument instrument, float volume) {
-	volume = max((float)0.0, min(volume, (float)1.0));
+	volume = clampValue(volume, (float)0.0, (float)1.0);
 
 	setWaveFormSelect(true);
 	for (byte op = OPERATOR1; op <= OPERATOR2; op ++) {
@@ -582,7 +582,7 @@ void OPL2::setInstrument(byte channel, Instrument instrument, float volume) {
  * proper output levels for the operator(s).
  */
 void OPL2::setDrumInstrument(Instrument instrument, float volume) {
-	volume = max((float)0.0, min(volume, (float)1.0));
+	volume = clampValue(volume, (float)0.0, (float)1.0);
 	byte channel = drumChannels[instrument.type - INSTRUMENT_TYPE_BASS];
 
 	setWaveFormSelect(true);
@@ -624,7 +624,7 @@ void OPL2::setDrumInstrument(Instrument instrument, float volume) {
  */
 void OPL2::playNote(byte channel, byte octave, byte note) {
 	setKeyOn(channel, false);
-	setBlock(channel, min(octave, (byte)NUM_OCTAVES));
+	setBlock(channel, clampValue(octave, (byte)0, (byte)NUM_OCTAVES));
 	setFNumber(channel, noteFNumbers[note % 12]);
 	setKeyOn(channel, true);
 }
@@ -642,7 +642,7 @@ void OPL2::playDrum(byte drum, byte octave, byte note) {
 
 	setDrums(drumState & ~drumBits[drum]);
 	byte drumChannel = drumChannels[drum];
-	setBlock(drumChannel, min(octave, (byte)NUM_OCTAVES));
+	setBlock(drumChannel, clampValue(octave, (byte)0, (byte)NUM_OCTAVES));
 	setFNumber(drumChannel, noteFNumbers[note % NUM_NOTES]);
 	setDrums(drumState | drumBits[drum]);
 }
@@ -1118,4 +1118,17 @@ byte OPL2::getWaveForm(byte channel, byte operatorNum) {
 void OPL2::setWaveForm(byte channel, byte operatorNum, byte waveForm) {
 	byte value = getOperatorRegister(0xE0, channel, operatorNum) & 0xF8;
 	setOperatorRegister(0xE0, channel, operatorNum, value + (waveForm & 0x07));
+}
+
+
+/**
+ * Clamp the given value to be between the given minimum and maximum.
+ */
+template <typename T>
+T OPL2::clampValue(T value, T min, T max) {
+	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
+		return constrain(value, min, max);
+	#else
+		return std::max(min, std::min(value, max));
+	#endif
 }

--- a/src/OPL2.cpp
+++ b/src/OPL2.cpp
@@ -1123,6 +1123,11 @@ void OPL2::setWaveForm(byte channel, byte operatorNum, byte waveForm) {
 
 /**
  * Clamp the given value to be between the given minimum and maximum.
+ *
+ * @param value - The value to clamp.
+ * @param min - Minimum clamping value.
+ * @param max - Maximum clamping vlue.
+ * @return The value clamped between the given min and max.
  */
 template <typename T>
 T OPL2::clampValue(T value, T min, T max) {

--- a/src/OPL2.h
+++ b/src/OPL2.h
@@ -21,7 +21,7 @@
 
 	// !!! IMPORTANT !!!
 	// In order to correctly compile the library for your platform be sure to set the correct BOARD_TYPE below.
-	#define BOARD_TYPE OPL2_BOARD_TYPE_ARDUINO
+	#define BOARD_TYPE OPL2_BOARD_TYPE_RASPBERRY_PI
 
 	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
 		#define PIN_LATCH 10
@@ -102,9 +102,8 @@
 		#include <Arduino.h>
 	#else
 		#include <stdint.h>
+		#include <algorithm>
 		typedef uint8_t byte;
-		#define min(a, b) ((a) < (b) ? (a) : (b))
-		#define max(a, b) ((a) > (b) ? (a) : (b))
 		#define PROGMEM 
 	#endif
 
@@ -229,6 +228,9 @@
 			void setWaveForm(byte channel, byte operatorNum, byte waveForm);
 
 		protected:
+			template <typename T>
+			T clampValue(T value, T min, T max);
+
 			byte pinReset   = PIN_RESET;
 			byte pinAddress = PIN_ADDR;
 			byte pinLatch   = PIN_LATCH;

--- a/src/OPL2.h
+++ b/src/OPL2.h
@@ -21,7 +21,7 @@
 
 	// !!! IMPORTANT !!!
 	// In order to correctly compile the library for your platform be sure to set the correct BOARD_TYPE below.
-	#define BOARD_TYPE OPL2_BOARD_TYPE_RASPBERRY_PI
+	#define BOARD_TYPE OPL2_BOARD_TYPE_ARDUINO
 
 	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
 		#define PIN_LATCH 10

--- a/src/TuneParser.cpp
+++ b/src/TuneParser.cpp
@@ -529,7 +529,7 @@ byte TuneParser::parseNoteLength(Voice voice) {
  * @param nMax - Maximum value of the number.
  * @return The number at the current command position in the voice or TP_NAN.
  */
-byte TuneParser::parseNumber(Voice voice, byte nMin, byte nMax) {
+byte TuneParser::parseNumber(Voice voice, int nMin, int nMax) {
 	char nextDigit = pgm_read_byte_near(voice.pattern + voice.position + 1);
 	if (nextDigit < '0' || nextDigit > '9') {
 		return TP_NAN;

--- a/src/TuneParser.h
+++ b/src/TuneParser.h
@@ -76,7 +76,7 @@ class TuneParser {
 		void parseNote(Voice& voice);
 		void parseRest(Voice& voice);
 		byte parseNoteLength(Voice voice);
-		byte parseNumber(Voice voice, byte nMin, byte nMax);
+		byte parseNumber(Voice voice, int nMin, int nMax);
 
 	private:
 		OPL3Duo* opl3 = NULL;


### PR DESCRIPTION
This replaces the `min` and `max` macros with a new function `clampValue` to fix #73.

Tested with
- Arduino
- Raspberry Pi
- Teensy
- ESP8266 (NodeMCU)
- STM32 (Blue Pill)
