### PR TITLE
Small improvements

### DIFF
--- a/src/OPL2.cpp
+++ b/src/OPL2.cpp
@@ -86,6 +86,12 @@ OPL2::OPL2(byte reset, byte address, byte latch) : OPL2::OPL2() {
  * Initialize the YM3812.
  */
 void OPL2::begin() {
+	#ifdef OPL_SERIAL_DEBUG
+		Serial.begin(115200);
+		while(!Serial);
+		Serial.println("OPL serial debug enabled");
+	#endif
+
 	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
 		SPI.begin();
 		SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
@@ -325,6 +331,13 @@ byte OPL2::getRegisterOffset(byte channel, byte operatorNum) {
  * @param value - The value to write to the register.
  */
 void OPL2::write(byte reg, byte value) {
+	#ifdef OPL_SERIAL_DEBUG
+		Serial.print("reg: ");
+		Serial.print(reg, HEX);
+		Serial.print(", val: ");
+		Serial.println(value, HEX);
+	#endif
+
 	// Write OPL2 address.
 	digitalWrite(pinAddress, LOW);
 	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
@@ -623,7 +636,9 @@ void OPL2::setDrumInstrument(Instrument instrument, float volume) {
  * Play a note of a certain octave on the given channel.
  */
 void OPL2::playNote(byte channel, byte octave, byte note) {
-	setKeyOn(channel, false);
+	if (getKeyOn(channel)) {
+		setKeyOn(channel, false);
+	}
 	setBlock(channel, clampValue(octave, (byte)0, (byte)NUM_OCTAVES));
 	setFNumber(channel, noteFNumbers[note % 12]);
 	setKeyOn(channel, true);

--- a/src/OPL3.cpp
+++ b/src/OPL3.cpp
@@ -92,12 +92,12 @@ void OPL3::reset() {
 	delay(1);
 	digitalWrite(pinReset, HIGH);
 
-	// Initialize chip registers.
+	// Initialize chip registers and enable OPL3 mode temporarily.
 	setChipRegister(0x00, 0x00);
 	setChipRegister(0x08, 0x40);
 	setChipRegister(0xBD, 0x00);
 	setChipRegister(0x104, 0x00);
-	setChipRegister(0x105, 0x00);
+	setChipRegister(0x105, 0x01);
 
 	// Initialize all channel and operator registers.
 	for (byte i = 0; i < getNumChannels(); i ++) {
@@ -113,6 +113,9 @@ void OPL3::reset() {
 			setOperatorRegister(0xE0, i, j, 0x00);
 		}
 	}
+
+	// Disable OPL3 mode.
+	setChipRegister(0x105, 0x00);
 }
 
 
@@ -194,6 +197,15 @@ void OPL3::setOperatorRegister(byte baseRegister, byte channel, byte operatorNum
  * @param value - The value to write to the register.
  */
 void OPL3::write(byte bank, byte reg, byte value) {
+	#ifdef OPL_SERIAL_DEBUG
+		Serial.print("bank: ");
+		Serial.print(bank);
+		Serial.print(", reg: ");
+		Serial.print(reg, HEX);
+		Serial.print(", val: ");
+		Serial.println(value, HEX);
+	#endif
+
 	digitalWrite(pinAddress, LOW);
 	digitalWrite(pinBank, (bank & 0x01) ? HIGH : LOW);
 	#if BOARD_TYPE == OPL2_BOARD_TYPE_ARDUINO
@@ -447,9 +459,7 @@ void OPL3::set4OPChannelEnabled(byte channel4OP, bool enable) {
  * @param enable - Enables 4-OP channels when true.
  */
 void OPL3::setAll4OPChannelsEnabled(bool enable) {
-	for (byte i = 0; i < getNum4OPChannels(); i ++) {
-		set4OPChannelEnabled(i, enable);
-	}
+	setChipRegister(0x0104, enable ? 0x3F : 0x00);
 }
 
 

--- a/src/OPL3.h
+++ b/src/OPL3.h
@@ -63,7 +63,7 @@
 			virtual void setOPL3Enabled(bool enable);
 			virtual bool is4OPChannelEnabled(byte channel4OP);
 			virtual void set4OPChannelEnabled(byte channel4OP, bool enable);
-			void setAll4OPChannelsEnabled(bool enable);
+			virtual void setAll4OPChannelsEnabled(bool enable);
 
 			bool isPannedLeft (byte channel);
 			bool isPannedRight(byte channel);

--- a/src/OPL3Duo.h
+++ b/src/OPL3Duo.h
@@ -37,6 +37,8 @@
 			virtual void setOPL3Enabled(byte synthUnit, bool enable);
 			virtual bool is4OPChannelEnabled(byte channel4OP);
 			virtual void set4OPChannelEnabled(byte channel4OP, bool enable);
+			virtual void setAll4OPChannelsEnabled(bool enable);
+			void setAll4OPChannelsEnabled(byte synthUnit, bool enable);
 		protected:
 			byte pinUnit = PIN_UNIT;
 


### PR DESCRIPTION
* Proper reset functions for OPL3 and OPL3Duo. If there would've been no hard reset then all registers of channels 9 .. 17 would not be cleared due to the chips operating in OPL2 mode. **The shadow register do not yet take into account OPL2 vs OPL3 mode!**
* PlayNote will only reset the KEY-ON if it is set. This was giving some glitches with some of the drum sounds,
* Enabling all 4-op channels will now set register 0x104 once instead of multiple writes for each 4-op channel.
* Added enable all 4-op channels functions for opl3Duo.
* Added an option to debug the data written to the board by defining OPL_SERIAL_DEBUG in opl2.h