### PR TITLE
TeensyMidi example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the OPL2 / OPL3 audio library for the OPL2 Audio Board 
 * Emulation with DosBox; you can use the board to output MIDI music (Teensy++ 2.0 and later)
 * Use the board directly as a synthesizer by using the [OPL3BankEditor](https://github.com/Wohlstand/OPL3BankEditor) software by Wohlstand
 
-Current library version is 2.1.1, 11th July 2021
+Current library version is 2.1.2, 7th March 2022
 
 ### OPL2 Audio Board
 The OPL2 Audio Board is fun and easy board to get started with an OPL2 synthesizer. It is built around the YM3812 OPL2 chip that gives you 9 channels with 2-operators each to produce the classic OPL2 sound that you may remember from early 90s computer games.

--- a/build
+++ b/build
@@ -20,7 +20,7 @@ echo "\033[1;34m        \\/       \\/           \\/       \\/     \033[0m"
 echo "For the \033[1;36mOPL2 Audio Board\033[0m and \033[1;36mOPL3 Duo!\033[0m synthesizers"
 echo ""
 echo "Installation script for Raspberry Pi and compatibles"
-echo "Library version 2.1.1, 11th of July 2021"
+echo "Library version 2.1.2, 7th of March 2022"
 echo "Copyright (c) 2016-2021 Maarten Janssen, Cheerful"
 echo ""
 

--- a/examples/OPL2AudioBoard/Teensy/TeensyMidi/TeensyMidi.ino
+++ b/examples/OPL2AudioBoard/Teensy/TeensyMidi/TeensyMidi.ino
@@ -162,8 +162,8 @@ void onNoteOn(byte midiChannel, byte note, byte velocity) {
 		opl2Note   = note % 12;
 	} else {
 		note = midiChannelMap[midiChannel].instrument.transpose;
-		octave = note / 12;
-		note = note % 12;
+		opl2Octave = note / 12;
+		opl2Note = note % 12;
 	}
 
 	// Set instrument registers and play note.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino OPL2
-version=2.1.1
+version=2.1.2
 author=Maarten Janssen <maarten@cheerful.nl>
 maintainer=Maarten Janssen <maarten@cheerful.nl>
 sentence=Use this library to control the OPL2 Audio Board or OPL3 Duo!

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2019 Maarten Janssen
+Copyright (c) 2016-2022 Maarten Janssen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This fixes issue #92 where the TeensyMidi example for OPL2 Audio Board
fails to compile.